### PR TITLE
fix indent when filename is not simple letter or digit

### DIFF
--- a/src/folder-title.ts
+++ b/src/folder-title.ts
@@ -21,7 +21,7 @@ export const setupTitle = (plugin: FileExplorerNoteCount, vault: Vault, revert =
 export const setTitle = (item: FileItem, vault: Vault) => {
     if (item.file.extension != "md") { return }
 
-    let idMatch = item.file.basename.match(/([0-9]+|[a-z]+)/g)!
+    let idMatch = item.file.basename.match(/([^\/\\]+)/g)!
     if (idMatch) {
         let indentCount = (idMatch.length - 1)
         let indentStr = (indentCount * 20).toString() + "px"


### PR DESCRIPTION
If a filename contains anything other than a letters or digits - such as space or underscore - or even if it has letters _and_ digits, the indenting gets mashed up in file view.

The regex incorrectly counts only groups of letters or groups of digits to find indent level.

This fix sorts that out by changing the regex to look for groups of chars which are anything except `/` or `\`. 

I'm a dev but not done an obsidian plugin before, so unclear how to make and test a new plugin.  But tested the regex by hacking the main.js in my `.obsidian\plugins\file-explorer-markdown-titles` dir. 

It turned this (note indent level matches number of spaces in filename which matches first title)

![image](https://user-images.githubusercontent.com/5367728/205396534-abc8f755-303e-49ee-bf9d-b5e0f5169d62.png)

into this:

![image](https://user-images.githubusercontent.com/5367728/205396570-6579cd11-b239-478a-a69b-0f5c666abb38.png)

As desired!  I don't claim to have exhaustively tested this change however :-)

NOTE : I do know the plugin is kinda pointless on files named like above where filename matches first title, but they are in a directory in my vault made as part of an import, and I'd still like it to look ok in the file view as I really need and appreciate the plugin for my new notes which use zettelkasten-style filenames.
